### PR TITLE
Clean up small grammatical errors

### DIFF
--- a/source/about_deploy_rb.md
+++ b/source/about_deploy_rb.md
@@ -19,7 +19,7 @@ example, it provides the `mina restart` command.
 
 The magic of Mina is in the new commands it gives you.
 
-The `queue` command queues up Bash commands to be ran on the remote server.
+The `queue` command queues up Bash commands to be run on the remote server.
 If you invoke `mina restart`, it will invoke the task above and run the queued
 commands on the remote server `your.server.com` via SSH.
 

--- a/source/deploying.md
+++ b/source/deploying.md
@@ -16,7 +16,7 @@ you.
     task :deploy do
       deploy do
         # Put things that prepare the empty release folder here.
-        # Commands queued here will be ran on a new release directory.
+        # Commands queued here will be run on a new release directory.
         invoke :'git:clone'
         invoke :'bundle:install'
 
@@ -83,7 +83,7 @@ commands to restart the webserver process. Once this in complete, you're done!
 ### What about failure?
 
 If it fails at any point, the release path will be deleted. If any commands are
-queued using the `to :clean` block, they will be ran. It will be as if nothing
+queued using the `to :clean` block, they will be run. It will be as if nothing
 happened. Lets see what happens if a build fails:
 
     $

--- a/source/helpers/queue.md
+++ b/source/helpers/queue.md
@@ -3,7 +3,7 @@ title: queue
 group: Helpers
 ---
 
-This queues code to be ran to the current code bucket (defaults to `:default`).
+This queues code to be run to the current code bucket (defaults to `:default`).
 At the end of the execution, before Mina exits, all queued commands are executed
 remotely.
 

--- a/source/index.md
+++ b/source/index.md
@@ -40,7 +40,7 @@ server.
     -----> Done. Deployed v4
 
 Compare this to the likes of Vlad or Capistrano, where each command
-is ran separately on their own SSH sessions. Mina only creates *one* SSH
+is run in a separate SSH session. Mina only creates *one* SSH
 session per deploy, minimizing the SSH connection overhead.
 
 See [the deploying guide](deploying.html) for more information.
@@ -71,7 +71,7 @@ All your settings are stored in a Ruby file
       queue 'sudo service restart apache'
     end
 
-In this file, you will define tasks that *queue* up commands to be ran
+In this file, you will define tasks that *queue* up commands to be run
 remotely via SSH.
 
 Mina is built on [Rake](http://http://rake.rubyforge.org/). Mina configuration

--- a/source/subtasks.md
+++ b/source/subtasks.md
@@ -22,5 +22,5 @@ task.
     end
 
 In this example above, if you type `mina down`, it simply invokes the other
-subtasks which queues up their commands. The commands will be ran after
+subtasks which queues up their commands. The commands will be run after
 everything.


### PR DESCRIPTION
This corrects a few misused "ran"s in the docs.  No need to use "ran" when we're talking about the future.  :-)

Thanks for mina!
